### PR TITLE
Bump cmake_minimum_required version to 3.3.0 to avoid CMP0063 warnings

### DIFF
--- a/cmake/Modules/Platform/Emscripten.cmake
+++ b/cmake/Modules/Platform/Emscripten.cmake
@@ -2,10 +2,10 @@
 # It teaches CMake about the Emscripten compiler, so that CMake can generate makefiles
 # from CMakeLists.txt that invoke emcc.
 
-# At the moment this required minimum version is not exact (i.e. we do not know of a feature that needs CMake 3.0.0 specifically)
-# It is possible that CMake 3.0.0 is too old and will not actually work. If you do find such a case, please report it at Emscripten
+# At the moment this required minimum version is not exact (i.e. we do not know of a feature that needs CMake 3.3.0 specifically)
+# It is possible that CMake 3.3.0 is too old and will not actually work. If you do find such a case, please report it at Emscripten
 # bug tracker to revise the minimum requirement. See also https://github.com/emscripten-core/emsdk/issues/108
-cmake_minimum_required(VERSION 3.0.0)
+cmake_minimum_required(VERSION 3.3.0)
 
 # To use this toolchain file with CMake, invoke CMake with the following command line parameters
 # cmake -DCMAKE_TOOLCHAIN_FILE=<EmscriptenRoot>/cmake/Modules/Platform/Emscripten.cmake


### PR DESCRIPTION
See: https://cmake.org/cmake/help/latest/policy/CMP0063.html

Setting `cmake_minimum_required` to at least 3.3.0 automatically
applies the NEW policy for CMP0063, which avoids warnings coming from
`em_link_js_library` and similar.